### PR TITLE
add --nofitview argument

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -5,7 +5,7 @@
 #include "file.h"
 
 #define USAGE_STR "\
-Usage: %s --new <config file> | --restore <save state file>\n\
+Usage: %s --new <config file> | --restore <save state file> [--nofitview]\n\
 \n\
 The options are as follows:\n\
 \n\
@@ -17,7 +17,7 @@ int args_process(int argc, char** argv, simulation *sim) {
   simulation_config sim_config;
   int load_config_status;
 
-  if (argc != 3) {
+  if (argc < 3 || argc > 4) {
     printf(USAGE_STR, argv[0]);
     return 0;
   }
@@ -38,6 +38,18 @@ int args_process(int argc, char** argv, simulation *sim) {
   } else {
     printf(USAGE_STR, argv[0]);
     return 0;
+  }
+
+  sim->no_fit_view = 0;
+  if (argc > 3) {
+    if (0 == strcmp("--nofitview", argv[3])) {
+      sim->no_fit_view = 1;
+      printf("You have specified to not fit the view based on current simulation range.\nThe rendering will use the original world range of %f,%f,%f,%f\n", sim->orig_world_range[0].x, sim->orig_world_range[0].y, sim->orig_world_range[1].x, sim->orig_world_range[1].y);
+    }
+    else {
+      printf(USAGE_STR, argv[0]);
+      return 0;
+    }
   }
 
   return 1;

--- a/src/file.c
+++ b/src/file.c
@@ -86,6 +86,11 @@ int file_read_simulation(char* path, simulation* sim) {
     fread(&sim->frontbuffer[i].direction.y, sizeof(double), 1, fp);
   }
 
+  fread(&sim->orig_world_range[0].x, sizeof(double), 1, fp);
+  fread(&sim->orig_world_range[0].y, sizeof(double), 1, fp);
+  fread(&sim->orig_world_range[1].x, sizeof(double), 1, fp);
+  fread(&sim->orig_world_range[1].y, sizeof(double), 1, fp);
+
   fclose(fp);
   return 1;
 }
@@ -106,6 +111,11 @@ int file_write_simulation(char* path, simulation* sim) {
     fwrite(&sim->frontbuffer[i].direction.x, sizeof(double), 1, fp);
     fwrite(&sim->frontbuffer[i].direction.y, sizeof(double), 1, fp);
   }
+
+  fwrite(&sim->orig_world_range[0].x, sizeof(double), 1, fp);
+  fwrite(&sim->orig_world_range[0].y, sizeof(double), 1, fp);
+  fwrite(&sim->orig_world_range[1].x, sizeof(double), 1, fp);
+  fwrite(&sim->orig_world_range[1].y, sizeof(double), 1, fp);
 
   fclose(fp);
   return 1;

--- a/src/gl/render.c
+++ b/src/gl/render.c
@@ -12,9 +12,15 @@
 
 void render_frontbuffer(simulation* sim, void* anything) {
   int i;
-  fp_xy world_range[2];
+  fp_xy local_world_range[2];
+  fp_xy *world_range;
 
-  simulation_find_range_of_particles(sim->frontbuffer, sim->num_particles, world_range);
+  if (sim->no_fit_view)
+    world_range = sim->orig_world_range;
+  else {
+    world_range = local_world_range;
+    simulation_find_range_of_particles(sim->frontbuffer, sim->num_particles, world_range);
+  }
 
   glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
   glClear(GL_COLOR_BUFFER_BIT);

--- a/src/simulation.c
+++ b/src/simulation.c
@@ -65,7 +65,10 @@ printf("setting pos = %f,%f\n", sim->frontbuffer[i].position.x, sim->frontbuffer
     sim->frontbuffer[i].direction.x = RANDOM_DOUBLE(config->initial_direction_range[0].x, config->initial_direction_range[1].x);
     sim->frontbuffer[i].direction.y = RANDOM_DOUBLE(config->initial_direction_range[0].y, config->initial_direction_range[1].y);
 printf("setting dir = %f,%f\n", sim->frontbuffer[i].direction.x, sim->frontbuffer[i].direction.y);
-  } 
+  }
+
+  /* set the original world range before any particles move. */
+  simulation_find_range_of_particles(sim->frontbuffer, sim->num_particles, sim->orig_world_range);
 }
 
 void simulation_free(simulation* sim) {

--- a/src/simulation.h
+++ b/src/simulation.h
@@ -15,6 +15,8 @@ typedef struct {
   double max_speed;
   /** @deprecated */
   long tick_frequency_nanoseconds;
+  unsigned short no_fit_view;
+  fp_xy orig_world_range[2];
 } simulation;
 
 typedef struct {


### PR DESCRIPTION
This PR adds a `--no-fit-view` command line argument. For now, only the GL build uses this argument.

When you specify this command line argument, the application will **_NOT_** fit the view live based on the current simulation range.

Instead, it will fit the view based only on the original range of the particles in the simulation, even as the particles move inside and outside of that range. For some configurations where the particles start far away from each and over time collapse and spiral toward each other, this could give a more holistic vantage point of the simulation.